### PR TITLE
Supply 'startswith' with tuple of prefixes

### DIFF
--- a/screenshot.py
+++ b/screenshot.py
@@ -16,7 +16,7 @@ def start():
         start()
 
 def checkURL(url):
-    if url.startswith('https://steamcommunity.com/id/' or 'https://steamcommunity.com/profiles/'):
+    if url.startswith(('https://steamcommunity.com/id/', 'https://steamcommunity.com/profiles/')):
         return 1
     else:
         print('The inserted value is not a valid Steam URL.')


### PR DESCRIPTION
Thank you very much for your program, it did the job great!

When you use 'or' operator in Python with non-None strings, it always returns operand on the left, so `'https://steamcommunity.com/id/' or 'https://steamcommunity.com/profiles/'` always returns `'https://steamcommunity.com/id/'`.

This means the `startswith` method never checks if a given string starts with `'https://steamcommunity.com/profiles/'`.

I have made a fix so `startswith` now supplied with tuple of string, checking every option.